### PR TITLE
Build arguments for build errors seen on GCC 15.1.1

### DIFF
--- a/hook.go
+++ b/hook.go
@@ -14,7 +14,7 @@ package hook
 #cgo darwin CFLAGS: -x objective-c -Wno-deprecated-declarations
 #cgo darwin LDFLAGS: -framework Cocoa
 
-#cgo linux CFLAGS:-I/usr/src
+#cgo linux CFLAGS:-I/usr/src -std=gnu17
 #cgo linux LDFLAGS: -L/usr/src -lX11 -lXtst
 #cgo linux LDFLAGS: -lX11-xcb -lxcb -lxcb-xkb -lxkbcommon -lxkbcommon-x11
 //#cgo windows LDFLAGS: -lgdi32 -luser32


### PR DESCRIPTION
- Issues: https://github.com/robotn/gohook/issues/63

## Description

Add build flag to set GCC language version to get builds to pass.
