### PR TITLE
Fix unset_modifier_mask to handle duplicate keyup events

### DIFF
--- a/hook/windows/hook_c.h
+++ b/hook/windows/hook_c.h
@@ -68,7 +68,7 @@ static inline void set_modifier_mask(unsigned short int mask) {
 
 // Unset the native modifier mask for future events.
 static inline void unset_modifier_mask(unsigned short int mask) {
-	current_modifiers ^= mask;
+	current_modifiers &= ~mask;
 }
 
 // Get the current native modifier mask state.


### PR DESCRIPTION
In some cases Windows can send multiple keyup events for modifier keys and `current_modifiers` becomes broken as a result. This PR fixes `unset_modifier_mask` to use `&= ~` instead of `^=` to unset a bit.

## Details

For some reason my system issues multiple Ctrl keyup events when I do following:
1. Press Ctrl
2. Press Shift
3. Release Ctrl
4. Release Shift

Gohook sees the following events
1. KEYDOWN Ctrl
2. KEYDOWN Shift
3. KEYUP Ctrl
4. KEYUP Ctrl
5. KEYUP Shift

And as a result of XOR'ing the mask remains in invalid state, it has Ctrl bit set